### PR TITLE
remove duplicate switch for `sett`

### DIFF
--- a/gravel.brf
+++ b/gravel.brf
@@ -148,7 +148,6 @@ assign onewaypenalty =
 
 assign surfacepenalty
         switch surface=asphalt                                       1.5
-        switch surface=sett switch smoothness=good|excellent         0.1  0.3 # behauene Pflastersteine
         switch surface=paved switch smoothness=good|excellent        0.3  0.4 # befestigte(harte)Oberfl sche
         switch concrete=plates                                       1.5        # Betonplattenwege
         switch surface=concrete|paving_stones|wood|metal             0.5      # Beton, Pflastersteine (geschnitzt), Holz, Metall


### PR DESCRIPTION
`surface=sett` in combination with `smoothness=good|excellent` is duplicated in the gravel profile.

This commit removes the switch which leads to penalty values which are too low (IMHO).

The correct values are applied in the switch statement 4 lines later: <https://github.com/cxberlin/brouter-profiles/blob/main/gravel.brf#L155>